### PR TITLE
🐛  make html.dat path relocatable

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,20 +1,19 @@
 name = "HTML_Entities"
 desc = "Entities from HTML data tables"
 authors = ["ScottPJones <scottjones@alum.mit.edu>"]
-keywords = ["Entities", "HTML"]
-license = "MIT"
-uuid = "7693890a-d069-55fe-a829-b4a6d304f0ee"
-version = "1.0.1"
+version = "1.0.2"
 
 [deps]
+RelocatableFolders = "05181044-ff0b-4ac5-8273-598c1e38db00"
 StrTables = "9700d1a9-a7c8-5760-9816-a99fda30bb8f"
+
+[compat]
+RelocatableFolders = "1"
+StrTables = "1"
+julia = "1"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
 test = ["Test"]
-
-[compat]
-julia = "1"
-StrTables = "1"

--- a/src/HTML_Entities.jl
+++ b/src/HTML_Entities.jl
@@ -9,6 +9,7 @@ __precompile__()
 """
 module HTML_Entities
 using StrTables
+using RelocatableFolders
 
 VER = UInt32(1)
 
@@ -29,8 +30,8 @@ struct HTML_Table{T} <: AbstractEntityTable
 end
 
 function __init__()
-    global default =
-        HTML_Table(StrTables.load(joinpath(@__DIR__, "../data", "html.dat"))...)
+    html_data_path = @path joinpath(@__DIR__, "../data", "html.dat")
+    global default = HTML_Table(StrTables.load(html_data_path)...)
     nothing
 end
 end # module HTML_Entities


### PR DESCRIPTION
- `@__DIR__` hardcodes the file location and makes sysimages non-relocatable
- Bumps version to 1.0.2