### PR TITLE
added artifact for html.dat

### DIFF
--- a/Artifacts.toml
+++ b/Artifacts.toml
@@ -1,0 +1,2 @@
+[htmlnames]
+git-tree-sha1 = "813db2bcdc4c5c4cc1cdbd6583e6c6bd7eaca024"

--- a/Project.toml
+++ b/Project.toml
@@ -4,16 +4,18 @@ keywords = ["Entities", "HTML"]
 license = "MIT"
 desc = "Entities from HTML data tables"
 authors = ["ScottPJones <scottjones@alum.mit.edu>"]
-version = "1.0.2"
+version = "1.0.3"
 
 [deps]
+Artifacts = "56f22d72-fd6d-98f1-02f0-08ddc0907c33"
 RelocatableFolders = "05181044-ff0b-4ac5-8273-598c1e38db00"
 StrTables = "9700d1a9-a7c8-5760-9816-a99fda30bb8f"
 
 [compat]
+Artifacts = "1"
 RelocatableFolders = "1"
 StrTables = "1"
-julia = "1"
+julia = "1.6"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -4,6 +4,8 @@
 
 println("Running HTML entity build in ", pwd())
 
+using Artifacts
+using Base.Filesystem
 using StrTables
 
 VER = UInt32(1)
@@ -98,4 +100,14 @@ else
         println("Error creating HTML tables")
         println(sprint(showerror, ex, catch_backtrace()))
     end
+end
+
+if isfile(savfile)
+    artifact_toml = joinpath(@__DIR__, "..", "Artifacts.toml")
+    hash = artifact_hash("htmlnames", artifact_toml)
+    path = artifact_path(hash)
+    isdir(path) || mkpath(path)
+    cp(savfile, joinpath(path, basename(savfile)), force=true)
+
+    println("Artifact had created at ", path)
 end

--- a/src/HTML_Entities.jl
+++ b/src/HTML_Entities.jl
@@ -9,6 +9,7 @@ __precompile__()
 """
 module HTML_Entities
 using StrTables, RelocatableFolders
+using Artifacts
 
 VER = UInt32(1)
 
@@ -28,7 +29,7 @@ struct HTML_Table{T} <: AbstractEntityTable
     ind2c::Vector{UInt16}
 end
 
-const DATA_PATH = @path joinpath(@__DIR__, "../data", "html.dat")
+const DATA_PATH = @path joinpath(artifact"htmlnames", "html.dat")
 
 function __init__()
     global default = HTML_Table(StrTables.load(DATA_PATH)...)


### PR DESCRIPTION
Current version of the package breaks the use of an executable binary produced by PackageCompiler. The issue is absence of the directory with the HTML_Entities package on the machine which uses the binary. 

```julia
const DATA_PATH = @path joinpath(@__DIR__, "../data", "html.dat")
```

This patch changes this dependency to artefacts, which can be handled correctly by PackageCompiler.
